### PR TITLE
Add Husky

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,4 @@
+#!/usr/bin/env sh
+. "$(dirname -- "$0")/_/husky.sh"
+
+yarn lint:fix --max-warnings 0

--- a/package.json
+++ b/package.json
@@ -52,7 +52,8 @@
     "package": "rm *.vsix || true && vsce package --allow-missing-repository",
     "lint:ci": "yarn lint -- --max-warnings 0",
     "coverage": "open coverage/index.html",
-    "test": "jest --config jest.config.js"
+    "test": "jest --config jest.config.js",
+    "prepare": "husky install"
   },
   "devDependencies": {
     "@babel/core": "^7.19.3",
@@ -72,6 +73,7 @@
     "eslint-plugin-import": "^2.26.0",
     "eslint-plugin-prettier": "^4.2.1",
     "glob": "^8.0.3",
+    "husky": "^8.0.1",
     "jest": "^29.1.2",
     "prettier": "^2.7.1",
     "ts-jest": "^29.0.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2923,6 +2923,11 @@ human-signals@^2.1.0:
   resolved "https://registry.yarnpkg.com/human-signals/-/human-signals-2.1.0.tgz#dc91fcba42e4d06e4abaed33b3e7a3c02f514ea0"
   integrity sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==
 
+husky@^8.0.1:
+  version "8.0.1"
+  resolved "https://registry.yarnpkg.com/husky/-/husky-8.0.1.tgz#511cb3e57de3e3190514ae49ed50f6bc3f50b3e9"
+  integrity sha512-xs7/chUH/CKdOCs7Zy0Aev9e/dKOMZf3K1Az1nar3tzlv0jfqnYtu235bstsWTmXOR0EfINrPa97yy4Lz6RiKw==
+
 ieee754@^1.1.13:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/ieee754/-/ieee754-1.2.1.tgz#8eb7a10a63fff25d15a57b001586d177d1b0d352"


### PR DESCRIPTION
### Features and Changes

Adds the Husky pre-commit hook that runs lint with auto-fix, allowing 0 warnings.

### Dependencies

n/a

### Testing

- run `yarn install`
- add `const foo = 1` to the end of any file. Do this in an editor that doesn't auto-fix, e.g. vim.
- try to commit this file
