### PR TITLE
Fix bug where edit and copy buttons don't appear

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,12 +31,12 @@
       "view/item/context": [
         {
           "command": "growthbook.copyFeatureKey",
-          "when": "view == featuresList",
+          "when": "true",
           "group": "inline"
         },
         {
           "command": "growthbook.editFeature",
-          "when": "view == featuresList",
+          "when": "true",
           "group": "inline"
         }
       ]


### PR DESCRIPTION
### Features and Changes

Fixes a regression introduced in 2afca44af27a1698b51eae4337534cbd3120a865 

The `view == growthbook.featuresList` was a mistake for the `view/item/context` items—this should have no special conditions.

- Closes #5 


### Screenshots

<img width="389" alt="image" src="https://user-images.githubusercontent.com/113377031/219748912-328fe289-7f1f-4bc9-9870-07d0f8a7bdf9.png">
<img width="451" alt="image" src="https://user-images.githubusercontent.com/113377031/219749041-7a46092d-1fab-440b-b852-a1f85b5c2b31.png">

